### PR TITLE
For php API generation: reorder headers to prevent Override , add Content-Length if body is SplFileObject

### DIFF
--- a/modules/openapi-generator/src/main/resources/php/api.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api.mustache
@@ -632,9 +632,13 @@ use {{invokerPackage}}\ObjectSerializer;
 
         $headers = array_merge(
             $defaultHeaders,
-            $headerParams,
-            $headers
+            $headers,
+            $headerParams
         );
+
+        if($httpBody instanceof \SplFileObject) {
+            $headers['Content-Length'] = (string)$body->getSize();
+        }
 
         {{#servers.0}}
         $operationHosts = [{{#servers}}"{{{url}}}"{{^-last}}, {{/-last}}{{/servers}}];


### PR DESCRIPTION





<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

#### headerParams shouldn't be overwritten by i.e application/json when explicitly specified

(related to issue 5163, however that didn't do the trick for me)


i.e. a definition like this:

```
'/somewhere':
    post:
      ...
      parameters:
        - schema:
            type: string
            default: text/plain
            enum:
              - text/plain
          in: header
          name: Accept
```

currently result in a 'Accept' header of 'application/json' where it should be 'text/plain'



#### also added Content-Length to Header when body is SplFileObject

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh
  ./bin/utils/export_docs_generators.sh
  ``` 
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`, `5.1.x`, `6.0.x`
- [x] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.

@jebentier (2017/07), @dkarlovi (2017/07), @mandrean (2017/08), @jfastnacht (2017/09), @ackintosh (2017/09) heart, @ybelenko (2018/07), @renepardon (2018/12)
